### PR TITLE
Fixed metadata response provided by module for -H bootique flag.

### DIFF
--- a/bootique-docker/src/main/java/io/bootique/docker/DockerModuleProvider.java
+++ b/bootique-docker/src/main/java/io/bootique/docker/DockerModuleProvider.java
@@ -19,6 +19,7 @@
 package io.bootique.docker;
 
 import io.bootique.BQModuleProvider;
+import io.bootique.BQModuleMetadata.Builder;
 import io.bootique.di.BQModule;
 
 import java.lang.reflect.Type;
@@ -38,5 +39,11 @@ public class DockerModuleProvider implements BQModuleProvider {
     @Override
     public BQModule module() {
         return new DockerModule();
+    }
+
+    @Override
+    public Builder moduleBuilder() {
+        return BQModuleProvider.super.moduleBuilder()
+                .description("Provides integration with Java Docker Client library.");
     }
 }

--- a/bootique-docker/src/main/java/io/bootique/docker/HttpTransportDockerClientFactory.java
+++ b/bootique-docker/src/main/java/io/bootique/docker/HttpTransportDockerClientFactory.java
@@ -25,6 +25,8 @@ import com.github.dockerjava.core.DockerClientImpl;
 import com.github.dockerjava.transport.DockerHttpClient;
 import com.github.dockerjava.transport.SSLConfig;
 import com.github.dockerjava.zerodep.ZerodepDockerHttpClient;
+
+import io.bootique.annotation.BQConfig;
 import io.bootique.annotation.BQConfigProperty;
 import io.bootique.config.PolymorphicConfiguration;
 import io.bootique.value.Duration;
@@ -35,6 +37,7 @@ import java.net.URI;
  * @since 3.0.M1
  */
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "type", defaultImpl = NoEnvDockerClientFactory.class)
+@BQConfig("Configures Docker clients, providing injectable DockerClients object.")
 public abstract class HttpTransportDockerClientFactory implements PolymorphicConfiguration {
 
     protected Integer maxConnections;


### PR DESCRIPTION
Due to missing `@BQConfig` annotation for configuration no information on module was printed. Also no top-level module description was provided. Now all looks well.